### PR TITLE
Update PmdRulesDefinitionTest.java

### DIFF
--- a/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdRulesDefinitionTest.java
+++ b/sonar-pmd-plugin/src/test/java/org/sonar/plugins/pmd/PmdRulesDefinitionTest.java
@@ -44,7 +44,7 @@ class PmdRulesDefinitionTest {
         assertThat(repository.language()).isEqualTo(PmdConstants.LANGUAGE_KEY);
 
         List<Rule> rules = repository.rules();
-        assertThat(rules).hasSize(268);
+        assertThat(rules).hasSizeGreaterThan(268);
 
         for (Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
这里单测跑不通，容易让人误导，看起来是因为规则数量，但因为添加了p3c，故规则必然多与原有的268。
The unit test here fails to run, which can easily mislead people. It seems to be due to the number of rules, but since p3c was added, the number of rules inevitably exceeds the original 268.